### PR TITLE
optee ftpm: CFG_TA_FTPM_RPMB_STORAGE selects RPMB storage

### DIFF
--- a/platform/NVMem.c
+++ b/platform/NVMem.c
@@ -157,7 +157,7 @@ _plat__NvInitFromStorage()
 		objID = s_StorageObjectID + i;
 
 		// Attempt to open TEE persistent storage object.
-		Result = TEE_OpenPersistentObject(TEE_STORAGE_PRIVATE,
+		Result = TEE_OpenPersistentObject(CFG_FTPM_TA_TEE_STORAGE_ID,
 									      (void *)&objID,
 									      sizeof(objID),
 									      TA_STORAGE_FLAGS,
@@ -175,7 +175,7 @@ _plat__NvInitFromStorage()
 			}
 
 			// Storage object was not found, create it.
-			Result = TEE_CreatePersistentObject(TEE_STORAGE_PRIVATE,
+			Result = TEE_CreatePersistentObject(CFG_FTPM_TA_TEE_STORAGE_ID,
 										        (void *)&objID,
 										        sizeof(objID),
 										        TA_STORAGE_FLAGS,
@@ -313,7 +313,7 @@ _plat__NvWriteBack()
 			// Force storage stack to update its backing store
             TEE_CloseObject(s_NVStore[i]);
 
-            Result = TEE_OpenPersistentObject(TEE_STORAGE_PRIVATE,
+            Result = TEE_OpenPersistentObject(CFG_FTPM_TA_TEE_STORAGE_ID,
                                               (void *)&objID,
                                               sizeof(objID),
                                               TA_STORAGE_FLAGS,

--- a/sub.mk
+++ b/sub.mk
@@ -1,4 +1,5 @@
 CFG_FTPM_EMULATE_PPI ?= n
+CFG_FTPM_TA_TEE_STORAGE_ID ?= TEE_STORAGE_PRIVATE
 
 #
 # The fTPM needs to overwrite some of the header files used in the
@@ -76,6 +77,8 @@ cflags-platform/fTPM_event_log.c-y += -Wno-incompatible-pointer-types
 cflags-platform/EventLogPrint.c-y += -Wno-pointer-arith
 cflags-platform/EventLogPrint.c-y += -Wno-format-truncation
 cflags-platform/EventLogPrint.c-y += -Wno-restrict
+
+cppflags-y += -DCFG_FTPM_TA_TEE_STORAGE_ID=$(CFG_FTPM_TA_TEE_STORAGE_ID)
 
 srcs-y += platform/AdminPPI.c
 srcs-y += platform/Cancel.c


### PR DESCRIPTION
Adds configuration switch CFG_TA_FTPM_RPMB_STORAGE that, when enable, makes fTPM OP-TEE TA to explicitly use the eMMC RPMB secure storage of OP-TEE instead of OP-TEE private storage which depends on OP-TEE configuration. The configuration switch is default disabled for compatibility reasons.