### PR TITLE
user_ta_defines: fix TA version and description definition

### DIFF
--- a/include/user_ta_header_defines.h
+++ b/include/user_ta_header_defines.h
@@ -57,9 +57,7 @@
 #define TA_STACK_SIZE               (64 * 1024)
 #define TA_DATA_SIZE                (32 * 1024)
 
-#define TA_CURRENT_TA_EXT_PROPERTIES \
-    { "gp.ta.description", USER_TA_PROP_TYPE_STRING, \
-        "fTPM TA" }, \
-    { "gp.ta.version", USER_TA_PROP_TYPE_U32, &(const uint32_t){ 0x0010 } }
+#define TA_VERSION		"0.1"
+#define TA_DESCRIPTION		"fTPM TA"
 
 #endif /*USER_TA_HEADER_DEFINES_H*/

--- a/include/user_ta_header_defines.h
+++ b/include/user_ta_header_defines.h
@@ -49,13 +49,13 @@
 
 #include <ftpm_ta.h>
 
-#define TA_UUID                     TA_FTPM_UUID
+#define TA_UUID		TA_FTPM_UUID
 
-#define TA_FLAGS                    (TA_FLAG_SINGLE_INSTANCE | \
-				     TA_FLAG_INSTANCE_KEEP_ALIVE | \
-				     TA_FLAG_DEVICE_ENUM_TEE_STORAGE_PRIVATE)
-#define TA_STACK_SIZE               (64 * 1024)
-#define TA_DATA_SIZE                (32 * 1024)
+#define TA_FLAGS                (TA_FLAG_SINGLE_INSTANCE | \
+				 TA_FLAG_INSTANCE_KEEP_ALIVE | \
+				 TA_FLAG_DEVICE_ENUM_TEE_STORAGE_PRIVATE)
+#define TA_STACK_SIZE           (64 * 1024)
+#define TA_DATA_SIZE            (32 * 1024)
 
 #define TA_VERSION		"0.1"
 #define TA_DESCRIPTION		"fTPM TA"


### PR DESCRIPTION
Correct how TA version and description strings are defined OP-TEE devkit expects them from macros `TA_VERSION` and `TA_DESCRIPTION`. `TA_CURRENT_TA_EXT_PROPERTIES` here was bugged as it uses "gp.ta." prefix for the property names instead of "gpd.ta." as defined in GP TEE Internal Core API since release v1.1.