### PR TITLE
platform/NVMem:Fix stack overflow in _plat__NvInitFromStorage() on 64 bit architectures

### DIFF
--- a/platform/NVMem.c
+++ b/platform/NVMem.c
@@ -133,7 +133,7 @@ _plat__NvInitFromStorage()
 	UINT32 i;
 	BOOL initialized;
 	UINT32 objID;
-	UINT32 bytesRead;
+	size_t bytesRead;
 	TEE_Result Result;
 
 	// Don't re-initialize.


### PR DESCRIPTION
The `UINT32 bytesRead` stack variable declared in _plat__NvInitFromStorage() is passed as fourth parameter to 
 TEE_ReadObjectData()` which has following signature:

    TEE_Result TEE_ReadObjectData(TEE_ObjectHandle object, void *buffer,
                                  size_t size, size_t *count)

The type mismatch might cause stack overflow on 64 bit architectures where 64b-wide `size_t` value would be written to address of 32b-wide variable on stack.