### PR TITLE
ci: fix misspelling so that only xtest is run

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,4 +37,4 @@ jobs:
           ln -s ${OPTEE_FTPM_TO_TEST} ${TOP}/optee_ftpm
           cd ${TOP}/build
 
-          make -j$(nproc) check MEASURED_BOOT_FTPM=y CHECK_TEST=xtest XTEST_ARGS=regression_1041
+          make -j$(nproc) check MEASURED_BOOT_FTPM=y CHECK_TESTS=xtest XTEST_ARGS=regression_1041


### PR DESCRIPTION
The "make check" command line should pass "CHECK_TESTS=xtest" to run only xtest (and exclude the other tests: trusted-keys and rust), which was the intent in commit 0ce8f915e651 ("github: add CI workflow"). Fix the misspelling so that it really happens.

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
