### PR TITLE
platform/NVMem: fix _plat__NvEnable return codes

### DIFF
--- a/fTPM.c
+++ b/fTPM.c
@@ -154,7 +154,7 @@ TEE_Result TA_CreateEntryPoint(void)
     if (fTPMInitialized) {
         // We may have had TA_DestroyEntryPoint called but we didn't
         // actually get torn down. Re-NVEnable, just in case.
-        if (_plat__NVEnable(NULL) == 0) {
+        if (_plat__NVEnable(NULL)) {
             TEE_Panic(TEE_ERROR_BAD_STATE);
         }
         return TEE_SUCCESS;
@@ -164,7 +164,7 @@ TEE_Result TA_CreateEntryPoint(void)
     _admin__NvInitState();
 
     // If we fail to open fTPM storage we cannot continue.
-    if (_plat__NVEnable(NULL) == 0) {
+    if (_plat__NVEnable(NULL)) {
         TEE_Panic(TEE_ERROR_BAD_STATE);
     }
 

--- a/platform/NVMem.c
+++ b/platform/NVMem.c
@@ -101,6 +101,14 @@ static UINT64 s_blockMap = 0x0ULL;
 #error "NV block count exceeds 64 bit block map. Adjust block or NV size."
 #endif
 
+/*
+ * Return codes for _plat__NvEnable. Private to this file only, because
+ * callers should NOT compare to the errors for equality.
+ */
+#define _plat__NvEnable_RC_FAIL_UNRECOVERABLE -1
+#define _plat__NvEnable_RC_SUCCESS            0
+#define _plat__NvEnable_RC_FAIL_RECOVERABLE   1
+
 //
 // NV state
 //
@@ -385,7 +393,7 @@ _plat__NVEnable(
 
     // Don't re-open the backing store.
     if (s_NVInitialized) {
-        return 0;
+        return _plat__NvEnable_RC_SUCCESS;
     }
 
 	// Clear NV
@@ -412,10 +420,10 @@ _plat__NVEnable(
             // should we decide not to just TEE_Panic, we can continue
             // execution after (re)manufacture. Later an attempt at re-init
             // can be made by calling _plat__NvInitFromStorage again.
-            retVal = 0;
+            retVal = _plat__NvEnable_RC_FAIL_RECOVERABLE;
         }
         else {
-            retVal = 1;
+            retVal = _plat__NvEnable_RC_SUCCESS;
         }
 
         // Going to manufacture, zero flags
@@ -440,7 +448,7 @@ _plat__NVEnable(
         _admin__RestoreChipFlags();
 
 		// Success
-		retVal = 1;
+        retVal = _plat__NvEnable_RC_SUCCESS;
     }
 
     return retVal;


### PR DESCRIPTION
Per the doc comment, most of the returns in _plat__NvEnable are inverted (except the earliest one). This didn't result in bad behavior, as the library callers always got the correct early return, and the TA entry point callers, who never got the early return, assumed inverted behavior, but it makes the code difficult to follow. 

I've replaced the numbers with macros to avoid confusion. I've kept these macros local to the .c file because a) there wasn't a super logical header to put them in, and b) the error return conditions are just positive and negative (not specifically 1 and -1) so I don't want callers to be tempted to compare against them for equality. Let me know if a different approach here is prefered.

