### PR TITLE
Force build with CFG_WERROR=n

### DIFF
--- a/sub.mk
+++ b/sub.mk
@@ -1,3 +1,7 @@
+# As for now, fTPM implementation leads to too many build warnings for
+# OP-TEE configuration CFG_WERROR to be enable. Force it disabled.
+override CFG_WERROR := n
+
 CFG_FTPM_EMULATE_PPI ?= n
 CFG_FTPM_TA_TEE_STORAGE_ID ?= TEE_STORAGE_PRIVATE
 


### PR DESCRIPTION
Force CFG_WERROR=n when building fTPM because the implementation leads to too many warnings and prevents to build the OP-TEE test distribution (OP-TEE manifest and build repositories) with a generic CFG_WERROR=y.

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
