### PR TITLE
Disable strict-aliasing optimizations until they are fixed upstream

### DIFF
--- a/sub.mk
+++ b/sub.mk
@@ -36,6 +36,7 @@ global-incdirs_ext-y += $(CFG_MS_TPM_20_REF)/TPMCmd/tpm/include
 global-incdirs_ext-y += $(CFG_MS_TPM_20_REF)/TPMCmd/tpm/include/prototypes
 global-incdirs_ext-y += $(CFG_MS_TPM_20_REF)/TPMCmd/Platform/include
 
+cflags-y += -fno-strict-aliasing
 cflags-y += -Wno-cast-align
 cflags-y += -Wno-implicit-fallthrough
 cflags-y += -Wno-cast-function-type


### PR DESCRIPTION
While cleaning up a downstream build, I had to work out the implications of these warnings. My conclusion is that until  upstream ms-tpm-20-ref code is made safe, -fstrict-aliasing needs to be disabled because the warnings indicate that
those pieces may be optimized in a broken manner.

When building the ms-tpm-20-ref code with a modern gcc and -Wstrict-aliasing there are a number of these warnings that need to be addressed upstream:

 dereferencing type-punned pointer will break strict-aliasing rules

-Wstrict-aliasing is flagging code that may break with compiler optimizations that it unlocks. Since code in ms-tpm-20-ref is being flagged by this, it should not be built with these optimizations enabled for now. Setting -fno-strict-aliasing will both disable these unsafe optimizations and suppress the warnings.

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
